### PR TITLE
Add rule for unquoted `import` and `export` keywords in JSX

### DIFF
--- a/docs/rules/no-unquoted-import-or-export-in-jsx.md
+++ b/docs/rules/no-unquoted-import-or-export-in-jsx.md
@@ -1,0 +1,18 @@
+# No Unquoted Import or Export in JSX
+
+## Rule details
+
+Dependor can not differentiate between import/export keywords inside of JSX and real uses of those keywords.
+
+## Valid
+
+```jsx
+<p>{"this is a string with the words import and export"}</p>
+<p>this is a jsx text node with escaped {"import"} and {"export"} keywords</p>
+```
+
+## Invalid
+
+```jsx
+<p>this is a jsx text node with the words import and export</p>
+```

--- a/src/rules/no-unquoted-import-or-export-in-jsx.ts
+++ b/src/rules/no-unquoted-import-or-export-in-jsx.ts
@@ -1,0 +1,31 @@
+import { createRule } from '../utils';
+
+export const rule = createRule({
+  create(context) {
+    return {
+      JSXText(node) {
+        if (/import|export/.test(node.value)) {
+          context.report({
+            messageId: 'noUnquotedImportOrExportInJsx',
+            node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'Avoid unquoted import or export keywords in JSX',
+      recommended: true,
+      requiresTypeChecking: false,
+    },
+    messages: {
+      noUnquotedImportOrExportInJsx:
+        'Do not use import or export keywords without quotes in JSX',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  name: 'no-unquoted-import-or-export-in-jsx',
+  defaultOptions: [],
+});

--- a/tests/no-unquoted-import-or-export-in-jsx.test.ts
+++ b/tests/no-unquoted-import-or-export-in-jsx.test.ts
@@ -38,15 +38,8 @@ ruleTest.run('no-unquoted-import-or-export-in-jsx', rule, {
       code: `<p>You can not use unquoted import or export in jsx</p>`,
       errors: [
         {
-          column: 29,
-          endColumn: 35,
-          line: 1,
-          endLine: 1,
-          messageId: 'noUnquotedImportOrExportInJsx',
-        },
-        {
-          column: 39,
-          endColumn: 45,
+          column: 4,
+          endColumn: 52,
           line: 1,
           endLine: 1,
           messageId: 'noUnquotedImportOrExportInJsx',

--- a/tests/no-unquoted-import-or-export-in-jsx.test.ts
+++ b/tests/no-unquoted-import-or-export-in-jsx.test.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import tseslint from 'typescript-eslint';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as vitest from 'vitest';
+import { rule } from '../src/rules/no-unquoted-import-or-export-in-jsx';
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTest = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+      ecmaVersion: 2020,
+      projectService: {
+        allowDefaultProject: ['*.ts*'],
+        defaultProject: 'tsconfig.json',
+      },
+      tsconfigRootDif: path.join(__dirname, '..'),
+    },
+  },
+});
+
+ruleTest.run('no-unquoted-import-or-export-in-jsx', rule, {
+  valid: [
+    `<p>This is some text without problems</p>`,
+    `<Display text="export" />`,
+    `<div>{"you can use export and import in quotes"}</div>`,
+    `const foo = 'import';`,
+  ],
+  invalid: [
+    {
+      code: `<p>You can not use unquoted import or export in jsx</p>`,
+      errors: [
+        {
+          column: 29,
+          endColumn: 35,
+          line: 1,
+          endLine: 1,
+          messageId: 'noUnquotedImportOrExportInJsx',
+        },
+        {
+          column: 39,
+          endColumn: 45,
+          line: 1,
+          endLine: 1,
+          messageId: 'noUnquotedImportOrExportInJsx',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Dependor only parses a subset of JavaScript / TypeScript and can not actually parse JSX.

Since dependor ignores tokens it does not recognize, this is usually not a problem. But when JSX text includes the keywords `import` or `export` it can throw dependor off.

I may eventually be able to ignore most JSX using heuristics, but for now my solution is to lint for this particular case.

It is pretty easy to transform:

```jsx
<div>This use of the word import is a problem for dependor</div>
```

Into:

```jsx
<div>This use of the word {"import"} is not a problem for dependor</div>
```

Adding this to the eslint plugin makes these cases easier to spot.